### PR TITLE
Deadlock fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ install:
 
 script:
   - make test
-  # - make test-race
-  - make vet
+  - make test-race
+  - make vet 
   # - make bench
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 
 script:
   - make test
-  - make test-race
+  - make test-go-race
   - make vet 
   # - make bench
 

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -453,7 +453,7 @@ func (q *Query) finish() {
 	}
 
 	q.parentSpan.Finish()
-	q.c.queryDone <- q
+	go func() { q.c.queryDone <- q }()
 	close(q.ready)
 }
 


### PR DESCRIPTION
Fixing deadlock in the controller and finish func.
The deadlock was when in the controller was trying to check query is OK.
finish() is sending a query to non-buffered channel queryDone. And when there is a lot of requests this deadlock appears.
Resolution - send a query in a goroutine. queryDone is used for freeing controller resources.